### PR TITLE
Clear status bars if no data is available

### DIFF
--- a/LabormateProfessionStatusBarMixin.lua
+++ b/LabormateProfessionStatusBarMixin.lua
@@ -64,6 +64,7 @@ function LabormateProfessionStatusBarMixin:UpdateFromInfo(professionInfo)
     if not professionInfo or professionInfo.maxSkillLevel == 0 then
         self.currentValueLabel:SetText("")
         self.maxValueLabel:SetText("")
+        self.skillBarFillMask:SetPoint("CENTER", self.skillBarFillTexture, 0, -self.skillBarFillTexture:GetWidth());
         return
     end
 


### PR DESCRIPTION
This fixes a bug where if data that was previously available is no longer available, the profession status bar would stay filled to the previous level until new data was read. Now the bar will show empty when there is no data.