### PR TITLE
Fix Release Generation

### DIFF
--- a/.github/workflows/package_release_publish.yml
+++ b/.github/workflows/package_release_publish.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Create GitHub release
         if: ${{ !inputs.simulate }}
-        run: gh release create ${{ needs.package.outputs.version }} --fail-on-no-commits --generate-notes --verify-tag --repo Drakmyth/Labormate Labormate-${{ needs.package.outputs.version }}.zip
+        run: gh release create ${{ needs.package.outputs.version }} --generate-notes --verify-tag --repo Drakmyth/Labormate Labormate-${{ needs.package.outputs.version }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
* Remove fail on no new commits since this is purely manual and it will fail on duplicate tag anyway